### PR TITLE
autoload.php discover 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ composer.lock
 /.idea/
 /docker-compose-debug.yml
 /docker-compose.yml
+/.multi-tester.yml
+/tests/tmp/
+/tests/report.html
+/psalm.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 /coverage/
 /vendor/
 /.idea/
+/docker-compose-debug.yml
+/docker-compose.yml

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -31,5 +31,4 @@ if (!$loader = getLoader()) {
     exit(1);
 }
 
-echo "Composer's autoload.php not found in checked folders:\n - " . implode("\n - ", $possibleFolders) . "\n";
-exit(1);
+exit((new MultiTester())->run($argv) ? 0 : 1);

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -13,12 +13,18 @@ function includeIfExists($file)
 }
 
 //Check for autoload file
-if (
-    (!$loader = includeIfExists(__DIR__ . '/../vendor/autoload.php'))
-    && (!$loader = includeIfExists(__DIR__ . '/../../../autoload.php'))
-) {
-    echo "Composer's autoload.php file not found.";
-    exit(1);
+
+$possibleFolders = array_unique(array_filter(array_map('realpath', [
+        getcwd() . '/vendor',
+        __DIR__ . '/../vendor',
+        __DIR__ . '/../../..'
+]), 'file_exists'));
+
+foreach ($possibleFolders as $folder) {
+    if (includeIfExists("$folder/autoload.php")) {
+        exit((new MultiTester())->run($argv) ? 0 : 1);
+    }
 }
 
-exit((new MultiTester())->run($argv) ? 0 : 1);
+echo "Composer's autoload.php not found in checked folders:\n - " . implode("\n - ", $possibleFolders) . "\n";
+exit(1);

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -12,11 +12,20 @@ function includeIfExists($file)
     }
 }
 
+function getLoader()
+{
+    $cwd = getcwd();
+    $possibleFolders = ["$cwd/vendor", __DIR__ . '/../vendor', __DIR__ . '/../../..'];
+    foreach ($possibleFolders as $dir) {
+        if ($loader = includeIfExists($dir . '/autoload.php')) {
+            return $loader;
+        }
+    }
+    return false;
+}
+
 //Check for autoload file
-if (
-    (!$loader = includeIfExists(__DIR__ . '/../vendor/autoload.php'))
-    && (!$loader = includeIfExists(__DIR__ . '/../../../autoload.php'))
-) {
+if (!$loader = getLoader()) {
     echo "Composer's autoload.php file not found.";
     exit(1);
 }

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -5,14 +5,19 @@ use MultiTester\MultiTester;
 
 set_time_limit(-1);
 
-//Check for autoload file
-$cwd = getcwd();
-$path = "$cwd/vendor/autoload.php";
+function includeIfExists($file)
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
 
-if (file_exists($path)) {
-    require $path;
-} else {
-    echo "Composer's autoload.php not found in $cwd.";
+//Check for autoload file
+if (
+    (!$loader = includeIfExists(__DIR__ . '/../vendor/autoload.php'))
+    && (!$loader = includeIfExists(__DIR__ . '/../../../autoload.php'))
+) {
+    echo "Composer's autoload.php file not found.";
     exit(1);
 }
 

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -17,7 +17,8 @@ function getLoader()
     $cwd = getcwd();
     $possibleFolders = ["$cwd/vendor", __DIR__ . '/../vendor', __DIR__ . '/../../..'];
     foreach ($possibleFolders as $dir) {
-        if ($loader = includeIfExists($dir . '/autoload.php')) {
+        if (($loader = includeIfExists($dir . '/autoload.php'))
+            && class_exists('MultiTester\MultiTester')) {
             return $loader;
         }
     }

--- a/bin/multi-tester
+++ b/bin/multi-tester
@@ -17,9 +17,11 @@ function getLoader()
     $cwd = getcwd();
     $possibleFolders = ["$cwd/vendor", __DIR__ . '/../vendor', __DIR__ . '/../../..'];
     foreach ($possibleFolders as $dir) {
-        if (($loader = includeIfExists($dir . '/autoload.php'))
-            && class_exists('MultiTester\MultiTester')) {
-            return $loader;
+        if ($loader = includeIfExists($dir . '/autoload.php')) {
+            if (class_exists('MultiTester\MultiTester')) {
+                return $loader;
+            }
+            $loader->unregister();
         }
     }
     return false;


### PR DESCRIPTION
Hi!
I propose to change `autoload.php` discovery
This will allow to install your package globally.

I'm using my own dev docker images and [php-tests](https://github.com/alecrabbit/sh-php-dev-helper) helper and was unable to install `multi-tester` globally and have made a patch for [docker image](https://github.com/alecrabbit/docker-php73-cli-alpine-debug/blob/master/patch/multi-tester)