### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,10 @@ env:
 
 matrix:
   include:
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 7.4snapshot
+    - php: 7.4
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "composer/semver": "^1.0",
-        "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
+        "symfony/yaml": "^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/MultiTester/MultiTester.php
+++ b/src/MultiTester/MultiTester.php
@@ -11,8 +11,12 @@ use MultiTester\Traits\WorkingDirectory;
 
 class MultiTester
 {
-    use WorkingDirectory, MultiTesterFile, TravisFile, StorageDirectory, ProcStreams, Verbose;
-
+    use WorkingDirectory;
+    use MultiTesterFile;
+    use TravisFile;
+    use StorageDirectory;
+    use ProcStreams;
+    use Verbose;
     /**
      * @var array|File Composer package settings cache.
      */
@@ -25,7 +29,7 @@ class MultiTester
 
     public function __construct($storageDirectory = null)
     {
-        $this->storageDirectory = $storageDirectory ?: sys_get_temp_dir();
+        $this->storageDirectory = $storageDirectory ?? sys_get_temp_dir();
     }
 
     public function exec($command, $quiet = false)

--- a/src/MultiTester/Project.php
+++ b/src/MultiTester/Project.php
@@ -174,7 +174,7 @@ class Project
             $package = $this->getPackage();
             $tester = $this->getConfig()->getTester();
             $composerSettings = $tester->getComposerSettings($package);
-            $version = $this->filterVersion($settings['version'], array_keys($composerSettings ?: []));
+            $version = $this->filterVersion($settings['version'], array_keys($composerSettings ?? []));
 
             $settings['source'] = isset($composerSettings[$version]['source'])
                 ? $composerSettings[$version]['source']

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -47,11 +47,11 @@ class DirectoryTest extends TestCase
 
         touch("$testDirectory/dest/foo/bar");
 
-        $this->assertTrue(is_file("$testDirectory/dest/foo/bar"));
+        $this->assertFileExists("$testDirectory/dest/foo/bar");
 
         $this->assertTrue((new Directory("$testDirectory/dest/foo/bar"))->create());
 
-        $this->assertTrue(is_dir("$testDirectory/dest/foo/bar"));
+        $this->assertDirectoryExists("$testDirectory/dest/foo/bar");
 
         touch("$testDirectory/dest/foo/bar/biz");
 

--- a/tests/MultiTesterTest.php
+++ b/tests/MultiTesterTest.php
@@ -238,12 +238,12 @@ class MultiTesterTest extends TestCase
 
         $packages = $method->invoke($tester, 'pug-php/pug');
 
-        $this->assertTrue(is_array($packages));
+        $this->assertIsArray($packages);
         $this->assertArrayHasKey('3.2.0', $packages);
 
         $package = $packages['3.2.0'];
 
-        $this->assertTrue(is_array($package));
+        $this->assertIsArray($package);
         $this->assertArrayHasKey('name', $package);
         $this->assertArrayHasKey('version', $package);
         $this->assertSame('pug-php/pug', $package['name']);

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -360,7 +360,7 @@ class ProjectTest extends TestCase
         $settings = [];
         $seedSourceSetting->invokeArgs($project, [&$settings]);
 
-        $this->assertTrue(is_array($settings['source']));
+        $this->assertIsArray($settings['source']);
         $this->assertSame('git', $settings['source']['type']);
         $this->assertSame('https://github.com/pug-php/pug.git', $settings['source']['url']);
 
@@ -491,7 +491,7 @@ class ProjectTest extends TestCase
 
         $clone = $settings['clone'];
 
-        $this->assertTrue(is_array($clone));
+        $this->assertIsArray($clone);
         $this->assertCount(2, $clone);
         $this->assertSame('git clone https://github.com/pug-php/pug.git .', $clone[0]);
         $this->assertRegExp('/^git checkout [0-9a-f]+$/', $clone[1]);
@@ -653,13 +653,13 @@ class ProjectTest extends TestCase
         mkdir("$dir/$projectDir", 0777, true);
         chdir($dir);
 
-        $this->assertTrue(is_dir($projectDir));
+        $this->assertDirectoryExists($projectDir);
 
         $removeReplacedPackages = new ReflectionMethod($project, 'removeReplacedPackages');
         $removeReplacedPackages->setAccessible(true);
         $removeReplacedPackages->invoke($project);
 
-        $this->assertFalse(is_dir($projectDir));
+        $this->assertDirectoryNotExists($projectDir);
 
         chdir(sys_get_temp_dir());
         (new Directory($dir))->remove();


### PR DESCRIPTION
# Changed log
- Drop `php-5.x` version supports.
- Let the package require `php-7.1` version at least.
- Using the `??` syntax to replace `?:`.
- Using the `assertIsArray` to assert the result type is `array`.
- Using the `assertDirectoryExists` to assert the directory is existed.
- Using the `assertFileExists` to assert the specific file path is existed.